### PR TITLE
Event changes

### DIFF
--- a/events.py
+++ b/events.py
@@ -60,12 +60,15 @@ class QBEventsAndServices:
 
         #Has anything changed that we care about?  Raise events as required
         if completed_torrents and self.config_entry.options.get(CONF_EVENT_COMPLETE, DEFAULT_EVENT_COMPLETE):
-             self.hass.bus.async_fire(EVENT_COMPLETED, completed_torrents)
+            for torrent in completed_torrents:
+                self.hass.bus.async_fire(EVENT_COMPLETED, torrent)
 
         if added_torrents and self.config_entry.options.get(CONF_EVENT_ADDED, DEFAULT_EVENT_ADDED):
-            self.hass.bus.async_fire(EVENT_ADDED, added_torrents)
+            for torrent in added_torrents:
+                self.hass.bus.async_fire(EVENT_ADDED, torrent)
 
         if removed_torrents and self.config_entry.options.get(CONF_EVENT_REMOVED, DEFAULT_EVENT_REMOVED):
-            self.hass.bus.async_fire(EVENT_REMOVED, removed_torrents)
+            for torrent in removed_torrents:
+                self.hass.bus.async_fire(EVENT_REMOVED, torrent)
 
         return

--- a/helpers.py
+++ b/helpers.py
@@ -32,12 +32,12 @@ def get_version(client: Client):
     return client.qbittorrent_version
 
 def compare_torrents(client: Client):
-    #Return a dict containing all changed torrents and their new state
+    #Return a list containing all changed torrents and their new state
     global all_torrents_prev
     
-    completed_torrents= {}
-    added_torrents= {}
-    removed_torrents = {}
+    completed_torrents= []
+    added_torrents= []
+    removed_torrents = []
 
     #Retrieve current torrent info    
     all_torrents = client.torrents()
@@ -58,9 +58,12 @@ def compare_torrents(client: Client):
                     #See if it's just completed downloading
                     if found_torrent['completion_on'] > 0:
                         #It's just finished downloading
-                        completed_torrents[prev_hash] = prev_name
+
+                        #Get the torrent_specific details also - different information is returned in client.get_torrent() compared to client.torrents()
+                        found_torrent_detail = client.get_torrent(found_torrent['hash'])
+                        completed_torrents.append (found_torrent | found_torrent_detail)
             else:
-                removed_torrents[prev_hash] = prev_name
+                removed_torrents.append(torrent)
 
         for torrent in all_torrents:
             #See if any new torrents have been added - it won't be in the previous list
@@ -68,7 +71,9 @@ def compare_torrents(client: Client):
             hash = torrent['hash']
             new_torrent = find_torrent(x for x in all_torrents_prev if x['hash'] == hash)
             if new_torrent is None:
-                added_torrents[hash] = name
+                #Get the torrent_specific details also - different information is returned in client.get_torrent() compared to client.torrents()
+                added_torrent_detail = client.get_torrent(torrent['hash'])
+                added_torrents.append(torrent | added_torrent_detail)
 
     all_torrents_prev = all_torrents
  


### PR DESCRIPTION
Changed event handling to one event per torrent, instead of one event per collection of torrents.

Per-torrent information return is much more detailed - all possible metadata instead of just the hash.